### PR TITLE
fixes for Ubuntu 18.04

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,6 +1,8 @@
 # This dockerfile executes the build, it starts from the dev environment
 FROM hellodev
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # These are the build steps
 RUN BUILD_DIR=/usr/local/src/hello/build  \
 && mkdir $BUILD_DIR \ 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,8 @@
 # This file creates a container for deployment, it starts with the runtime environment
 FROM hellorun
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Copies the installer
 COPY hello*.deb /root
 

--- a/develop/Dockerfile
+++ b/develop/Dockerfile
@@ -9,7 +9,7 @@ build-essential \
 make \
 cmake \
 libboost-test-dev \
-libboost-program-options1.58-dev
+libboost-program-options1.65-dev
 
 # include the code
 COPY hello-cpp-linwin/ /usr/local/src/hello

--- a/run/Dockerfile
+++ b/run/Dockerfile
@@ -3,4 +3,4 @@ FROM ubuntu:latest
 
 # Be sure to install any runtime dependencies
 RUN apt-get clean && apt-get update && apt-get install -y \
-libboost-program-options1.58.0
+libboost-program-options1.65.1 apt-utils


### PR DESCRIPTION

[CMakeLists.txt](https://github.com/MatrixManAtYrService/lifecycle-snapshots/files/1998004/CMakeLists.txt)
Very helpful repo.  I tested it out on Ubuntu 18.04 and found `ubuntu:latest` used 18.04.

Therefore, a few small changes are needed.  I am not too familiar with `boost` but the version supported on Bionic does not seem to include what you used.  `apt-utils` was missing and an 
`ENV DEBIAN_FRONTEND noninteractive` 
was needed in a couple of the Dockerfiles.  And for some reason the CMakeLists.txt file not updated in my git commit so I have attached that. 